### PR TITLE
do not call nn-close as socket finalizer

### DIFF
--- a/nanomsg.scm
+++ b/nanomsg.scm
@@ -261,14 +261,11 @@
 
 ;; int nn_socket (int domain, int protocol)
 ;; OBS: args reversed
-;; TODO: add finalizer
 (define (nn-socket protocol #!optional (domain 'sp))
-  (set-finalizer!
-   (%nn-socket-box
-    (nn-assert ((foreign-lambda int nn_socket nn-domain nn-protocol)
-                domain
-                protocol)))
-   nn-close))
+ (%nn-socket-box
+  (nn-assert ((foreign-lambda int nn_socket nn-domain nn-protocol)
+              domain
+              protocol))))
 
 (define (nn-bind socket address)
   (%nn-endpoint-box


### PR DESCRIPTION
I need to control the timing of nn-close calls - so I can't rely on a finalizer, and calling nn-close multiple times on the same socket is an error. I propose removing the finalizer and telling users to call nn-close manually (potentially adding a with-socket or similar procedure if you want it to automatically close). This would mirror file handling and the TCP APIs and is how I would expect the nanomsg egg to behave.